### PR TITLE
add:Tasteの投稿

### DIFF
--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -95,6 +95,17 @@
                 { multiple: true, class: "select2" } %>
           </div>
 
+          <!-- 味覚選択 -->
+          <div>
+            <label for="review_taste_ids" class="block text-sm font-medium text-gray-700 mb-2">
+              味覚
+            </label>
+            <%= form.select :taste_ids, 
+                options_from_collection_for_select(Taste.all, :id, :name, @review.taste_ids), 
+                { prompt: '味覚を選択してください' }, 
+                { multiple: true, class: "select2" } %>
+          </div>
+
           <!-- レビュー本文 -->
           <div>
             <label for="review_body" class="block text-sm font-medium text-gray-700 mb-2">
@@ -195,7 +206,7 @@ document.addEventListener('DOMContentLoaded', function() {
       console.log('jQuery is available in inline script');
       try {
         $('.select2').select2({
-          placeholder: 'カテゴリを選択してください',
+          placeholder: '選択してください',
           allowClear: true,
           width: '100%',
           multiple: true,
@@ -227,7 +238,7 @@ window.addEventListener('load', function() {
     console.log('Initializing select2 on window load');
     try {
       $('.select2').select2({
-        placeholder: 'カテゴリを選択してください',
+        placeholder: '選択してください',
         allowClear: true,
         width: '100%',
         multiple: true,
@@ -256,7 +267,7 @@ document.addEventListener('turbo:load', function() {
     
     // 新しいselect2インスタンスを初期化
     $('.select2').select2({
-      placeholder: 'カテゴリを選択してください',
+      placeholder: '選択してください',
       allowClear: true,
       width: '100%',
       multiple: true,
@@ -281,7 +292,7 @@ document.addEventListener('turbo:render', function() {
     
     // 新しいselect2インスタンスを初期化
     $('.select2').select2({
-      placeholder: 'カテゴリを選択してください',
+      placeholder: '選択してください',
       allowClear: true,
       width: '100%',
       multiple: true,

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -81,31 +81,60 @@
                 </h3>
               </div>
 
-              <!-- Categories -->
-              <div class="mb-4">
-                <h4 class="text-sm font-medium text-gray-700 mb-2">カテゴリー</h4>
-                <div class="flex flex-wrap gap-2">
-                  <% if review.categories.any? %>
-                    <% review.categories.each do |category| %>
-                      <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-green-100 text-green-800">
-                        <%= category.name %>
+              <!-- Categories and Tastes -->
+              <div class="mb-4 space-y-3">
+                <!-- Categories -->
+                <div>
+                  <h4 class="text-sm font-medium text-gray-700 mb-2">カテゴリー</h4>
+                  <div class="flex flex-wrap gap-2">
+                    <% if review.categories.any? %>
+                      <% review.categories.each do |category| %>
+                        <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-green-100 text-green-800">
+                          <%= category.name %>
+                        </span>
+                      <% end %>
+                    <% else %>
+                      <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-gray-200 text-gray-700">
+                        なし
                       </span>
                     <% end %>
-                  <% else %>
-                    <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-gray-200 text-gray-700">
-                      なし
-                    </span>
-                  <% end %>
-                  <% review.tastes.each do |taste| %>
-                    <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-purple-100 text-purple-800">
-                      <%= taste.name %>
-                    </span>
-                  <% end %>
-                  <% review.regions.each do |region| %>
-                    <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-orange-100 text-orange-800">
-                      <%= region.name %>
-                    </span>
-                  <% end %>
+                  </div>
+                </div>
+
+                <!-- Tastes -->
+                <div>
+                  <h4 class="text-sm font-medium text-gray-700 mb-2">味覚</h4>
+                  <div class="flex flex-wrap gap-2">
+                    <% if review.tastes.any? %>
+                      <% review.tastes.each do |taste| %>
+                        <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-purple-100 text-purple-800">
+                          <%= taste.name %>
+                        </span>
+                      <% end %>
+                    <% else %>
+                      <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-gray-200 text-gray-700">
+                        なし
+                      </span>
+                    <% end %>
+                  </div>
+                </div>
+
+                <!-- Regions -->
+                <div>
+                  <h4 class="text-sm font-medium text-gray-700 mb-2">地域</h4>
+                  <div class="flex flex-wrap gap-2">
+                    <% if review.regions.any? %>
+                      <% review.regions.each do |region| %>
+                        <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-orange-100 text-orange-800">
+                          <%= region.name %>
+                        </span>
+                      <% end %>
+                    <% else %>
+                      <span class="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-gray-200 text-gray-700">
+                        なし
+                      </span>
+                    <% end %>
+                  </div>
                 </div>
               </div>
 

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -95,6 +95,17 @@
                 { multiple: true, class: "select2" } %>
           </div>
 
+          <!-- 味覚選択 -->
+          <div>
+            <label for="review_taste_ids" class="block text-sm font-medium text-gray-700 mb-2">
+              味覚
+            </label>
+            <%= form.select :taste_ids, 
+                options_from_collection_for_select(Taste.all, :id, :name, @review.taste_ids), 
+                { prompt: '味覚を選択してください' }, 
+                { multiple: true, class: "select2" } %>
+          </div>
+
           <!-- レビュー本文 -->
           <div>
             <label for="review_body" class="block text-sm font-medium text-gray-700 mb-2">
@@ -190,7 +201,7 @@ document.addEventListener('DOMContentLoaded', function() {
       console.log('jQuery is available in inline script');
       try {
         $('.select2').select2({
-          placeholder: 'カテゴリを選択してください',
+          placeholder: '選択してください',
           allowClear: true,
           width: '100%',
           multiple: true,
@@ -222,7 +233,7 @@ window.addEventListener('load', function() {
     console.log('Initializing select2 on window load');
     try {
       $('.select2').select2({
-        placeholder: 'カテゴリを選択してください',
+        placeholder: '選択してください',
         allowClear: true,
         width: '100%',
         multiple: true,
@@ -251,7 +262,7 @@ document.addEventListener('turbo:load', function() {
     
     // 新しいselect2インスタンスを初期化
     $('.select2').select2({
-      placeholder: 'カテゴリを選択してください',
+      placeholder: '選択してください',
       allowClear: true,
       width: '100%',
       multiple: true,
@@ -276,7 +287,7 @@ document.addEventListener('turbo:render', function() {
     
     // 新しいselect2インスタンスを初期化
     $('.select2').select2({
-      placeholder: 'カテゴリを選択してください',
+      placeholder: '選択してください',
       allowClear: true,
       width: '100%',
       multiple: true,

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -81,29 +81,61 @@
 
         <!-- Categories -->
         <div class="mb-6">
-          <h3 class="text-lg font-semibold text-gray-900 mb-3">カテゴリー</h3>
-          <div class="flex flex-wrap gap-2">
-            <% if @review.categories.any? %>
-              <% @review.categories.each do |category| %>
-                <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-green-100 text-green-800">
-                  <%= category.name %>
-                </span>
-              <% end %>
-            <% else %>
-              <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-gray-200 text-gray-700">
-                なし
-              </span>
-            <% end %>
-            <% @review.tastes.each do |taste| %>
-              <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-purple-100 text-purple-800">
-                <%= taste.name %>
-              </span>
-            <% end %>
-            <% @review.regions.each do |region| %>
-              <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-orange-100 text-orange-800">
-                <%= region.name %>
-              </span>
-            <% end %>
+          <h3 class="text-lg font-semibold text-gray-900 mb-3">カテゴリー・味覚・地域</h3>
+          <div class="space-y-3">
+            <!-- カテゴリー -->
+            <div>
+              <h4 class="text-sm font-medium text-gray-700 mb-2">カテゴリー</h4>
+              <div class="flex flex-wrap gap-2">
+                <% if @review.categories.any? %>
+                  <% @review.categories.each do |category| %>
+                    <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-green-100 text-green-800">
+                      <%= category.name %>
+                    </span>
+                  <% end %>
+                <% else %>
+                  <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-gray-200 text-gray-700">
+                    なし
+                  </span>
+                <% end %>
+              </div>
+            </div>
+            
+            <!-- 味覚 -->
+            <div>
+              <h4 class="text-sm font-medium text-gray-700 mb-2">味覚</h4>
+              <div class="flex flex-wrap gap-2">
+                <% if @review.tastes.any? %>
+                  <% @review.tastes.each do |taste| %>
+                    <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-purple-100 text-purple-800">
+                      <%= taste.name %>
+                    </span>
+                  <% end %>
+                <% else %>
+                  <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-gray-200 text-gray-700">
+                    なし
+                  </span>
+                <% end %>
+              </div>
+            </div>
+            
+            <!-- 地域 -->
+            <div>
+              <h4 class="text-sm font-medium text-gray-700 mb-2">地域</h4>
+              <div class="flex flex-wrap gap-2">
+                <% if @review.regions.any? %>
+                  <% @review.regions.each do |region| %>
+                    <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-orange-100 text-orange-800">
+                      <%= region.name %>
+                    </span>
+                  <% end %>
+                <% else %>
+                  <span class="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-gray-200 text-gray-700">
+                    なし
+                  </span>
+                <% end %>
+              </div>
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## 概要
Taste（味覚）をレビューに投稿できる機能を実装しました。Categoryと同じ実装パターンに従って実装しています。

## 変更内容

### 追加機能
- レビュー作成・編集フォームにTaste選択フィールドを追加
- レビュー詳細ページでTasteを分けて表示
- レビュー一覧ページでCategoryとTasteを分けて表示

### 修正ファイル
- `app/views/reviews/new.html.erb` - レビュー作成フォームにTaste選択を追加
- `app/views/reviews/edit.html.erb` - レビュー編集フォームにTaste選択を追加
- `app/views/reviews/show.html.erb` - レビュー詳細でTasteを分けて表示
- `app/views/reviews/index.html.erb` - レビュー一覧でCategoryとTasteを分けて表示

### 技術的な変更
- Select2のプレースホルダーテキストを「選択してください」に統一
- 既存のモデル関連（Review、Taste、ReviewTaste）は既に実装済み
- コントローラーのstrong parametersも既に対応済み

## 動作確認
- [ ] レビュー作成時にTasteを選択できる
- [ ] レビュー編集時にTasteを変更できる
- [ ] レビュー詳細ページでTasteが正しく表示される
- [ ] レビュー一覧ページでCategoryとTasteが分けて表示される
- [ ] Tasteが選択されていない場合は「なし」と表示される

## スクリーンショット
（必要に応じてスクリーンショットを添付）

## 関連Issue
Closes #（関連するIssue番号があれば）