### PR TITLE
add:regiraiton

### DIFF
--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -106,6 +106,17 @@
                 { multiple: true, class: "select2" } %>
           </div>
 
+          <!-- 地域選択 -->
+          <div>
+            <label for="review_region_ids" class="block text-sm font-medium text-gray-700 mb-2">
+              地域
+            </label>
+            <%= form.select :region_ids, 
+                options_from_collection_for_select(Region.all, :id, :name, @review.region_ids), 
+                { prompt: '地域を選択してください' }, 
+                { multiple: true, class: "select2" } %>
+          </div>
+
           <!-- レビュー本文 -->
           <div>
             <label for="review_body" class="block text-sm font-medium text-gray-700 mb-2">

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -106,6 +106,17 @@
                 { multiple: true, class: "select2" } %>
           </div>
 
+          <!-- 地域選択 -->
+          <div>
+            <label for="review_region_ids" class="block text-sm font-medium text-gray-700 mb-2">
+              地域
+            </label>
+            <%= form.select :region_ids, 
+                options_from_collection_for_select(Region.all, :id, :name, @review.region_ids), 
+                { prompt: '地域を選択してください' }, 
+                { multiple: true, class: "select2" } %>
+          </div>
+
           <!-- レビュー本文 -->
           <div>
             <label for="review_body" class="block text-sm font-medium text-gray-700 mb-2">


### PR DESCRIPTION
## 概要
レビュー投稿時に地域タグを選択できる機能を追加しました。Taste、Categoryと同様の実装内容で統一感のあるUI/UXを提供します。

## 変更内容
- レビュー投稿画面（new.html.erb）に地域選択フィールドを追加
- レビュー編集画面（edit.html.erb）に地域選択フィールドを追加
- Select2ライブラリを使用した複数選択可能なドロップダウン
- 既存のJavaScriptが自動的に適用され、Select2の初期化も実行

## 技術的な詳細
- Reviewモデルとコントローラーは既に地域タグに対応済み
- `region_ids`パラメータは既に許可済み
- 既存の関連付け（has_many :regions, through: :review_regions）を活用

## 動作確認項目
- [ ] レビュー投稿時に地域を選択できる
- [ ] 複数の地域を選択できる
- [ ] 選択した地域がレビュー詳細画面でタグとして表示される
- [ ] レビュー編集時に地域の変更ができる
- [ ] Select2の動作が正常（検索、複数選択、クリア機能）

## スクリーンショット
（必要に応じて追加）

## 関連Issue
（関連するIssue番号があれば記載）

## チェックリスト
- [ ] コードレビューを依頼した
- [ ] テストが通ることを確認した
- [ ] 既存の機能に影響がないことを確認した
- [ ] ドキュメントの更新が必要な場合は更新した